### PR TITLE
Fix extra sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v1.0 - [2024-04-04]
+## v1.0.1 - [2025-02-07]
 
-Initial release of nf-core/phylomarkercheck, created with the [nf-core](https://nf-co.re/) template.
+Bug fix release
 
 ### `Added`
 
@@ -16,3 +16,7 @@ Initial release of nf-core/phylomarkercheck, created with the [nf-core](https://
 ### `Dependencies`
 
 ### `Deprecated`
+
+## v1.0 - [2024-04-04]
+
+Initial release of nf-core/phylomarkercheck, created with the [nf-core](https://nf-co.re/) template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Initial release of nf-core/phylomarkercheck, created with the [nf-core](https://
 
 ### `Fixed`
 
+- [#3](<[https://github.com/biodiversitydata-se/sbdi-phylomarkercheck/pull/3](https://github.com/biodiversitydata-se/sbdi-phylomarkercheck/pull/3)>) Fix problem with too many sequences output for a set.
+
 ### `Dependencies`
 
 ### `Deprecated`

--- a/modules/local/emitcorrect.nf
+++ b/modules/local/emitcorrect.nf
@@ -52,7 +52,7 @@ process EMITCORRECT {
         anti_join(misplaced, by = join_by(seqid)) %>%
         inner_join(metadata, by = join_by(accession)) %>%
         group_by(species) %>%
-        slice_max(order_by = quality, n = ${meta.n}) %>%
+        slice_max(order_by = quality, n = ${meta.n}, with_ties = FALSE) %>%
         write_tsv("${prefix}.correct.tsv.gz")
 
     writeLines(


### PR DESCRIPTION
<!--
# nf-core/phylomarkercheck pull request

Many thanks for contributing to nf-core/phylomarkercheck!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/phylomarkercheck/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phylomarkercheck/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phylomarkercheck _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).

This should deal with the pipeline sometimes outputting more sequences in a set than defined.